### PR TITLE
Add ability to point to a shp file and clip to a polygon instead of a bbox

### DIFF
--- a/Model/gedi_etl_batch.py
+++ b/Model/gedi_etl_batch.py
@@ -1,11 +1,13 @@
 class Batch(object):
-    def __init__(self, product, bbox, dataset_label, crs, version, do_store_file, store_path="", dl_links=list(), batch_id=int()):
+    def __init__(self, product, bbox, dataset_label, crs, version, table_name, do_store_file, aoi_gdf=None, store_path="", dl_links=list(), batch_id=int()):
         self.product = product
         self.bbox = bbox
         self.dataset_label = dataset_label
         self.crs = crs
         self.version = version
+        self.table_name = table_name
         self.do_store_file = do_store_file
         self.store_path = store_path
+        self.aoi_gdf = aoi_gdf
         self.dl_links = dl_links
         self.batch_id = batch_id

--- a/run_batch.py
+++ b/run_batch.py
@@ -11,13 +11,13 @@ def main():
 
     try:
         parser = argparse.ArgumentParser()
+        # Take either a bounding box or a path to a shapefile defining a polygon aoi. 
+        # Either way, we will need to define a bounding box to get the files from the EarthData web service.
         bbox_group = parser.add_mutually_exclusive_group(required=True)
         bbox_group.add_argument('--bbox', type=str)
         bbox_group.add_argument('--aoi_path', type=str)
 
         parser.add_argument('--product', type=str, required=True)
-
-        # parser.add_argument('--bbox', type=str, required=True)
         parser.add_argument('--label', type=str, required=True)
         parser.add_argument('--crs', type=str, required=False)
         parser.add_argument('--store_file', type=bool, required=False)
@@ -26,10 +26,11 @@ def main():
         args = parser.parse_args()
 
         if args.aoi_path is not None:
-            df = geopandas.read_file(args.aoi_path)
-            bbox = [str(df.bounds.maxy[0]), str(df.bounds.minx[0]), str(df.bounds.miny[0]), str(df.bounds.maxx[0])]
+            aoi_gdf = geopandas.read_file(args.aoi_path)
+            bbox = [str(aoi_gdf.bounds.maxy[0]), str(aoi_gdf.bounds.minx[0]), str(aoi_gdf.bounds.miny[0]), str(aoi_gdf.bounds.maxx[0])]
         else:
             bbox=args.bbox.split(',')
+            aoi_gdf=None
 
         #create a batch object to load into the gedi_etl_batch table
         etl_batch = Batch(
@@ -40,6 +41,8 @@ def main():
             ,do_store_file = args.store_file or False
             ,store_path = args.store_path
             ,version = '001'
+            ,table_name = 'gedi_4a_data_complete' #this should be set based on the product, but we (I) haven't been good at naming tables consistently, so keeping it hardcoded.
+            ,aoi_gdf=aoi_gdf
         )
 
     except Exception as e:

--- a/run_batch.py
+++ b/run_batch.py
@@ -11,8 +11,13 @@ def main():
 
     try:
         parser = argparse.ArgumentParser()
+        bbox_group = parser.add_mutually_exclusive_group(required=True)
+        bbox_group.add_argument('--bbox', type=str)
+        bbox_group.add_argument('--aoi_path', type=str)
+
         parser.add_argument('--product', type=str, required=True)
-        parser.add_argument('--bbox', type=str, required=True)
+
+        # parser.add_argument('--bbox', type=str, required=True)
         parser.add_argument('--label', type=str, required=True)
         parser.add_argument('--crs', type=str, required=False)
         parser.add_argument('--store_file', type=bool, required=False)
@@ -20,10 +25,16 @@ def main():
 
         args = parser.parse_args()
 
+        if args.aoi_path is not None:
+            df = geopandas.read_file(args.aoi_path)
+            bbox = [str(df.bounds.maxy[0]), str(df.bounds.minx[0]), str(df.bounds.miny[0]), str(df.bounds.maxx[0])]
+        else:
+            bbox=args.bbox.split(',')
+
         #create a batch object to load into the gedi_etl_batch table
         etl_batch = Batch(
              product=args.product
-            ,bbox=args.bbox.split(',')
+            ,bbox=bbox
             ,dataset_label=args.label
             ,crs=args.crs or 'epsg:4326'
             ,do_store_file = args.store_file or False


### PR DESCRIPTION
Path to a shapefile can be passed as a command line argument and used to clip the geodataframe before insert into postgres table. 

A bbox will still be derived from the shapefile and inserted into the geti_etl_batch table because a rectangle is needed to get the download links from the earthdata web service. 

I tested the process successfully with both a bbox and polygon after my changes.